### PR TITLE
Make prod settings use env variable for ALLOWED_HOSTS

### DIFF
--- a/superlists/settings/prod.py
+++ b/superlists/settings/prod.py
@@ -64,8 +64,9 @@ if not DEBUG:
     SESSION_COOKIE_SECURE = True
     X_FRAME_OPTIONS = "DENY"
 
-# ALLOWED_HOSTS = os.environ.get('ALLOWED_HOSTS')
-ALLOWED_HOSTS = ['*.compute-1.amazonaws.com', '127.0.0.1', 'localhost']
+ALLOWED_HOSTS = os.getenv('SITENAME')
+# TODO: remove commented out line below if exporting localhost works as well
+# ALLOWED_HOSTS = ['*.compute-1.amazonaws.com', '127.0.0.1', 'localhost']
 
 
 # Application definition


### PR DESCRIPTION
Made the production settings use an environment variable for `ALLOWED_HOSTS` instead of using explicit values.
Commented out the line just in case the change doesn't work as planned. Will remove if it does :)